### PR TITLE
Made code work with new version of pydantic

### DIFF
--- a/override_settings/override.py
+++ b/override_settings/override.py
@@ -1,6 +1,9 @@
 import contextlib
 from functools import wraps
-from pydantic import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    from pydantic import BaseSettings
 
 
 def async_override_settings(settings, **overrides):

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -1,5 +1,8 @@
 import pytest
-from pydantic import BaseSettings
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:
+    from pydantic import BaseSettings
 
 from override_settings import async_override_settings, override_settings, check_value
 


### PR DESCRIPTION
Pydantic moved BaseSettings to a separate package in newer versions.
This should fix the issues with newer pydantic versions.

Note: I don't have time at the moment to properly test that this works, and has no spelling mistakes. Please have a look at it before merging.